### PR TITLE
Reverte versão do pacote para 0.1.2

### DIFF
--- a/src/IATec.Shared.Api.Authentication.csproj
+++ b/src/IATec.Shared.Api.Authentication.csproj
@@ -10,7 +10,7 @@
 		<Description>Project developed to help IATec teams to develop their projects faster.</Description>
 		<Copyright>@IATec</Copyright>
 		<RootNamespace>IATec.Shared.Api.Authentication</RootNamespace>
-		<Version>1.0.0</Version>
+		<Version>0.1.2</Version>
 		<PackageIconUrl>https://assets-services-dev.sdasystems.org/images/icons/standard.library.icon.png</PackageIconUrl>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>


### PR DESCRIPTION
A versão do pacote no arquivo `IATec.Shared.Api.Authentication.csproj` foi alterada de `1.0.0` para `0.1.2`. Essa mudança pode indicar uma revisão na estratégia de versionamento, sugerindo que o projeto ainda está em estágio inicial ou alinhando-se a uma convenção específica.